### PR TITLE
fix x86-64-v4 for icc

### DIFF
--- a/cpu/microarchitectures.json
+++ b/cpu/microarchitectures.json
@@ -317,7 +317,7 @@
         "intel": [
             {
             "versions": "16.0:",
-            "name": "core-avx512",
+            "name": "skylake-avx512",
             "flags": "-march={name} -mtune={name}"
             }
         ],


### PR DESCRIPTION
I gave the wrong information for icc x86-64-v4 here: https://github.com/archspec/archspec-json/pull/70
I reproduced the problem, the fix, and checked with a compiler engineer. Icc accepts `-xcore-avx512`, but not `-march=core-avx512`. skylake-avx512 is the same as core-avx512 and accepted by march/mtune.

Thanks to @stephenmsachs for reporting the problem.